### PR TITLE
Use `require` whenever available to load viz.js

### DIFF
--- a/src/Graphics/Graphviz.js
+++ b/src/Graphics/Graphviz.js
@@ -2,9 +2,10 @@
 
 exports.viz_internal = function(data, format, engine, scale) {
   var v = undefined;
-  if (typeof window === "undefined") {
+  try {
     v = require('viz.js');
-  } else {
+  }
+  catch(error) {
     v = Viz;
   }
   return v(data, {format: format, engine: engine, scale: scale})


### PR DESCRIPTION
It used to be the case that I'd get an error like 
![2019-06-10-151420_516x144_scrot](https://user-images.githubusercontent.com/9491942/59231020-28f3d580-8b94-11e9-87f8-b8da08b19c3e.png) when trying to use this library in the browser. The offending code is here: 
![2019-06-10-151614_547x191_scrot](https://user-images.githubusercontent.com/9491942/59231045-3c06a580-8b94-11e9-92f7-838377e024f8.png).

The problem is that the existing code expects browsers to always have loaded viz.js as a globally available script and that `require` is never available in browsers. Using pulp's browserify command makes both assumptions incorrect (as you can see in the second screenshot, browserify makes a `require` function available).

Now the code tries `require` first and falls back to a global `Viz` only if `require` fails. 

I tested the new code on the command line (via `pulp test`), in the browser (via `pulp browserify`) with `require`, and in the browser without `require` (manually edited the JS bundle to skip the `require` attempt).